### PR TITLE
feat: provenance option

### DIFF
--- a/src/publish.ts
+++ b/src/publish.ts
@@ -8,7 +8,11 @@ import {
 } from "./utils";
 import type { publish as def } from "./types";
 
-export const publish: typeof def = async ({ defaultPackage, getPkgDir, provenance }) => {
+export const publish: typeof def = async ({
+  defaultPackage,
+  getPkgDir,
+  provenance,
+}) => {
   const tag = args._[0];
   if (!tag) throw new Error("No tag specified");
 

--- a/src/publish.ts
+++ b/src/publish.ts
@@ -8,7 +8,7 @@ import {
 } from "./utils";
 import type { publish as def } from "./types";
 
-export const publish: typeof def = async ({ defaultPackage, getPkgDir }) => {
+export const publish: typeof def = async ({ defaultPackage, getPkgDir, provenance }) => {
   const tag = args._[0];
   if (!tag) throw new Error("No tag specified");
 
@@ -36,5 +36,5 @@ export const publish: typeof def = async ({ defaultPackage, getPkgDir }) => {
     : activeVersion && semver.lt(pkg.version, activeVersion)
     ? "previous"
     : undefined;
-  await publishPackage(pkgDir, releaseTag);
+  await publishPackage(pkgDir, releaseTag, provenance);
 };

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,6 +1,11 @@
 export declare function publish(options: {
   defaultPackage: string;
   getPkgDir?: (pkg: string) => string;
+  /**
+   * Enables npm package provenance https://docs.npmjs.com/generating-provenance-statements
+   * @default false
+   */
+  provenance?: boolean;
 }): Promise<void>;
 
 export declare function release(options: {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -137,10 +137,14 @@ export function updateVersion(pkgPath: string, version: string): void {
 export async function publishPackage(
   pkdDir: string,
   tag?: string,
+  provenance?: boolean,
 ): Promise<void> {
   const publicArgs = ["publish", "--access", "public"];
   if (tag) {
     publicArgs.push(`--tag`, tag);
+  }
+  if (provenance) {
+    publicArgs.push(`--provenance`)
   }
   await runIfNotDry("npm", publicArgs, {
     cwd: pkdDir,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -144,7 +144,7 @@ export async function publishPackage(
     publicArgs.push(`--tag`, tag);
   }
   if (provenance) {
-    publicArgs.push(`--provenance`)
+    publicArgs.push(`--provenance`);
   }
   await runIfNotDry("npm", publicArgs, {
     cwd: pkdDir,


### PR DESCRIPTION
Adds a `provenance` option to pass the --provenance flag when calling `npm publish` 

We could also do this through configuration, but I don't think it hurts to be able to configure it directly.
https://docs.npmjs.com/generating-provenance-statements#using-third-party-package-publishing-tools