### PR TITLE
refactor: use mri to parse args

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,14 +26,13 @@
   },
   "dependencies": {
     "execa": "^7.1.1",
-    "minimist": "^1.2.8",
+    "mri": "^1.2.0",
     "picocolors": "^1.0.0",
     "prompts": "^2.4.2",
     "publint": "^0.1.11",
     "semver": "^7.5.1"
   },
   "devDependencies": {
-    "@types/minimist": "^1.2.2",
     "@types/node": "^18.16.9",
     "@types/prompts": "^2.4.4",
     "@types/semver": "^7.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,12 +1,16 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 dependencies:
   execa:
     specifier: ^7.1.1
     version: 7.1.1
-  minimist:
-    specifier: ^1.2.8
-    version: 1.2.8
+  mri:
+    specifier: ^1.2.0
+    version: 1.2.0
   picocolors:
     specifier: ^1.0.0
     version: 1.0.0
@@ -21,9 +25,6 @@ dependencies:
     version: 7.5.1
 
 devDependencies:
-  '@types/minimist':
-    specifier: ^1.2.2
-    version: 1.2.2
   '@types/node':
     specifier: ^18.16.9
     version: 18.16.9
@@ -284,10 +285,6 @@ packages:
     requiresBuild: true
     dev: true
     optional: true
-
-  /@types/minimist@1.2.2:
-    resolution: {integrity: sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==}
-    dev: true
 
   /@types/node@18.16.9:
     resolution: {integrity: sha512-IeB32oIV4oGArLrd7znD2rkHQ6EDCM+2Sr76dJnrHwv9OHBTTM6nuDLK9bmikXzPa0ZlWMWtRGo/Uw4mrzQedA==}
@@ -671,10 +668,6 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       brace-expansion: 2.0.1
-    dev: false
-
-  /minimist@1.2.8:
-    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
     dev: false
 
   /mri@1.2.0:

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,9 +5,9 @@ import type { Options as ExecaOptions, ExecaReturnValue } from "execa";
 import { execa } from "execa";
 import type { ReleaseType } from "semver";
 import semver from "semver";
-import minimist from "minimist";
+import mri from "mri";
 
-export const args = minimist(process.argv.slice(2));
+export const args = mri(process.argv.slice(2));
 
 export const isDryRun = !!args.dry;
 


### PR DESCRIPTION
`mri` is smaller and faster. Should be good enough for our current parsed args.

Comparison: https://github.com/lukeed/mri#minimist