### PR TITLE
chore: update publint

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "mri": "^1.2.0",
     "picocolors": "^1.0.0",
     "prompts": "^2.4.2",
-    "publint": "^0.1.16",
+    "publint": "^0.2.0",
     "semver": "^7.5.4"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ dependencies:
     specifier: ^2.4.2
     version: 2.4.2
   publint:
-    specifier: ^0.1.16
-    version: 0.1.16
+    specifier: ^0.2.0
+    version: 0.2.0
   semver:
     specifier: ^7.5.4
     version: 7.5.4
@@ -349,7 +349,7 @@ packages:
       fs.realpath: 1.0.0
       inflight: 1.0.6
       inherits: 2.0.4
-      minimatch: 5.1.4
+      minimatch: 5.1.6
       once: 1.4.0
     dev: false
 
@@ -362,7 +362,7 @@ packages:
     resolution: {integrity: sha512-yemi4pMf51WKT7khInJqAvsIGzoqYXblnsz0ql8tM+yi1EKYTY1evX4NAbJrLL/Aanr2HyZeluqU+Oi7MGHokw==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
     dependencies:
-      minimatch: 5.1.4
+      minimatch: 5.1.6
     dev: false
 
   /inflight@1.0.6:
@@ -405,8 +405,8 @@ packages:
     engines: {node: '>=12'}
     dev: false
 
-  /minimatch@5.1.4:
-    resolution: {integrity: sha512-U0iNYXt9wALljzfnGkhFSy5sAC6/SCR3JrHrlsdJz4kF8MvhTRQNiC59iUi1iqsitV7abrNAJWElVL9pdnoUgw==}
+  /minimatch@5.1.6:
+    resolution: {integrity: sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==}
     engines: {node: '>=10'}
     dependencies:
       brace-expansion: 2.0.1
@@ -488,8 +488,8 @@ packages:
       sisteransi: 1.0.5
     dev: false
 
-  /publint@0.1.16:
-    resolution: {integrity: sha512-wJgk7HnXDT5Ap0DjFYbGz78kPkN44iQvDiaq8P63IEEyNU9mYXvaMd2cAyIM6OgqXM/IA3CK6XWIsRq+wjNpgw==}
+  /publint@0.2.0:
+    resolution: {integrity: sha512-h8lxdjhQjpDw+A4BgY4sE7Z4CU3x5tCGGpERVdKGDQmWMtr1P7kvptJS2P10HhmNnS7Yeny37zfQE5+xRZ6nig==}
     engines: {node: '>=16'}
     hasBin: true
     dependencies:

--- a/src/release.ts
+++ b/src/release.ts
@@ -13,7 +13,7 @@ import {
 } from "./utils.ts";
 import type { release as def } from "./types.d.ts";
 import { publint } from "publint";
-import { printMessage } from "publint/utils";
+import { formatMessage } from "publint/utils";
 
 export const release: typeof def = async ({
   repo,
@@ -43,10 +43,10 @@ export const release: typeof def = async ({
 
   const { pkg, pkgPath, pkgDir } = getPackageInfo(selectedPkg, getPkgDir);
 
-  const messages = await publint({ pkgDir });
+  const { messages } = await publint({ pkgDir });
 
   if (messages.length) {
-    for (const message of messages) console.log(printMessage(message, pkg));
+    for (const message of messages) console.log(formatMessage(message, pkg));
     const { yes }: { yes: boolean } = await prompts({
       type: "confirm",
       name: "yes",


### PR DESCRIPTION
Updates `publint` to v0.2 and handles the breaking change. This new version will now warn for setups like:

```json
  "exports": {
    ".": {
      "types": "./index.d.ts",
      "require": "./index.cjs",
      "import": "./index.mjs"
    }
  },
```

So pretty much most of our packages will be affected, but shouldn't block the release step. TypeScript 😢 