### PR TITLE
fix: resolve pkgDir to absolute path

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -20,7 +20,7 @@ export function getPackageInfo(
   pkgName: string,
   getPkgDir: ((pkg: string) => string) | undefined = (pkg) => `packages/${pkg}`,
 ) {
-  const pkgDir = getPkgDir(pkgName);
+  const pkgDir = path.resolve(getPkgDir(pkgName));
   const pkgPath = path.resolve(pkgDir, "package.json");
   const pkg = JSON.parse(readFileSync(pkgPath, "utf-8")) as {
     name: string;
@@ -135,7 +135,7 @@ export function updateVersion(pkgPath: string, version: string): void {
 }
 
 export async function publishPackage(
-  pkdDir: string,
+  pkgDir: string,
   tag?: string,
   provenance?: boolean,
 ): Promise<void> {
@@ -147,7 +147,7 @@ export async function publishPackage(
     publicArgs.push(`--provenance`);
   }
   await runIfNotDry("npm", publicArgs, {
-    cwd: pkdDir,
+    cwd: pkgDir,
   });
 }
 


### PR DESCRIPTION
Resolve `pkgDir` to an absolute path. This value is passed to `publint` and `execa`'s `cwd` option. For example, before `"packages/vite"`; after `"/Users/foo/vite/packages/vite"`.

I don't think (?) passing a relative path works for publint, maybe it works for execa, but using absolute anyways should be safest.