### PR TITLE
feat(publish): add packageManager option

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ release({
       ).toString(),
     ),
   generateChangelog: (pkg, version) => {},
-  // use getPkgDir when not using a monorepo. Default to `packages/${pkg}`
+  // Use getPkgDir when not using a monorepo. Default to `packages/${pkg}`
   getPkgDir: (pkg) => ".",
 });
 ```
@@ -35,7 +35,11 @@ import { publish } from "@vitejs/release-scripts";
 publish({
   // Used when tag is not `pkg@version`
   defaultPackage: "release-scripts",
-  // use getPkgDir when not in a monorepo. Default to `packages/${pkg}`
+  // Use getPkgDir when not in a monorepo. Default to `packages/${pkg}`
   getPkgDir: (pkg) => ".",
+  // Publish with provenance https://docs.npmjs.com/generating-provenance-statements
+  provenance: true,
+  // Package manager that runs the publish command
+  packageManager: "pnpm",
 });
 ```

--- a/src/publish.ts
+++ b/src/publish.ts
@@ -12,6 +12,7 @@ export const publish: typeof def = async ({
   defaultPackage,
   getPkgDir,
   provenance,
+  packageManager,
 }) => {
   const tag = args._[0];
   if (!tag) throw new Error("No tag specified");
@@ -40,5 +41,5 @@ export const publish: typeof def = async ({
     : activeVersion && semver.lt(pkg.version, activeVersion)
     ? "previous"
     : undefined;
-  await publishPackage(pkgDir, releaseTag, provenance);
+  await publishPackage(pkgDir, releaseTag, provenance, packageManager);
 };

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -6,6 +6,11 @@ export declare function publish(options: {
    * @default false
    */
   provenance?: boolean;
+  /**
+   * Package manager that runs the publish command
+   * @default "npm"
+   */
+  packageManager?: "npm" | "pnpm";
 }): Promise<void>;
 
 export declare function release(options: {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -138,6 +138,7 @@ export async function publishPackage(
   pkgDir: string,
   tag?: string,
   provenance?: boolean,
+  packageManager: "npm" | "pnpm" = "npm",
 ): Promise<void> {
   const publicArgs = ["publish", "--access", "public"];
   if (tag) {
@@ -146,7 +147,7 @@ export async function publishPackage(
   if (provenance) {
     publicArgs.push(`--provenance`);
   }
-  await runIfNotDry("npm", publicArgs, {
+  await runIfNotDry(packageManager, publicArgs, {
     cwd: pkgDir,
   });
 }


### PR DESCRIPTION
In the recent Vite 5 beta release, `npm publish` was having trouble publishing `vite`. We got:

```
npm ERR! Cannot set properties of null (setting 'peer')

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/patak/.npm/_logs/2023-08-24T16_12_00_148Z-debug-0.log
```

Running `pnpm publish` instead fixes it, and I'm not really sure why. It could be pnpm installing dependencies in a certain way that npm fails.

Figured I add a new option instead of hardcoding it so we don't need a major bump, and also `npm publish` should work fine for our other packages, only `vite` is hitting this problem strangely.