### PR TITLE
fix(publish): set --no-git-checks for pnpm

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -147,6 +147,9 @@ export async function publishPackage(
   if (provenance) {
     publicArgs.push(`--provenance`);
   }
+  if (packageManager === "pnpm") {
+    publicArgs.push(`--no-git-checks`);
+  }
   await runIfNotDry(packageManager, publicArgs, {
     cwd: pkgDir,
   });


### PR DESCRIPTION
We're publishing in CI with a detached HEAD and pnpm doesn't like that. But I can't find where exactly we did that though 🤔 

The publish logs: https://github.com/vitejs/vite/actions/runs/6200513283/job/16835349291