### PR TITLE
chore: add repository for npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,10 @@
       "import": "./dist/index.js"
     }
   },
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:vitejs/release-scripts.git"
+  },
   "scripts": {
     "build": "tnode scripts/build.ts",
     "prettier": "pnpm prettier-ci --write",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:vitejs/release-scripts.git"
+    "url": "git+https://github.com/vitejs/release-scripts.git"
   },
   "scripts": {
     "build": "tnode scripts/build.ts",


### PR DESCRIPTION
In order for us to quickly find the repository from the npm site, add the repository field for package.json.