### PR TITLE
feat: set tag message

### DIFF
--- a/src/release.ts
+++ b/src/release.ts
@@ -106,7 +106,7 @@ export const release: typeof def = async ({
     step("\nCommitting changes...");
     await runIfNotDry("git", ["add", "-A"]);
     await runIfNotDry("git", ["commit", "-m", `release: ${tag}`]);
-    await runIfNotDry("git", ["tag", tag]);
+    await runIfNotDry("git", ["tag", "-a", "-m", tag, tag]);
   } else {
     console.log("No changes to commit.");
     return;


### PR DESCRIPTION
I have
```
[tag]
	gpgsign = true
```
in my git config and that makes the `git tag` to create [annotated tags](https://git-scm.com/book/en/v2/Git-Basics-Tagging#:~:text=are%20available%20too.-,Annotated%20Tags,-Creating%20an%20annotated) instead of lightweight tags.
Because annotated tags require a message, everytime I release Vite, the editor pops up to enter the message 😅. I always put the message same as the tag name. So I automated that.

It shouldn't affect others.
