### PR TITLE
fix: detect 404 in `getActiveVersion` by `--json`

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -159,13 +159,17 @@ export async function getActiveVersion(
   npmName: string,
 ): Promise<string | undefined> {
   try {
-    const { stdout } = await run("npm", ["info", npmName, "version", "--json"], { stdio: "pipe" });
+    const { stdout } = await run(
+      "npm",
+      ["info", npmName, "version", "--json"],
+      { stdio: "pipe" },
+    );
     return JSON.parse(stdout);
   } catch (e: any) {
     // Not published yet
     if (e.stdout) {
       const stdout = JSON.parse(e.stdout);
-      if (stdout.error.code === 'E404') {
+      if (stdout.error.code === "E404") {
         return;
       }
     }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -159,11 +159,16 @@ export async function getActiveVersion(
   npmName: string,
 ): Promise<string | undefined> {
   try {
-    return (await run("npm", ["info", npmName, "version"], { stdio: "pipe" }))
-      .stdout;
+    const { stdout } = await run("npm", ["info", npmName, "version", "--json"], { stdio: "pipe" });
+    return JSON.parse(stdout);
   } catch (e: any) {
     // Not published yet
-    if (e.stderr.startsWith("npm ERR! code E404")) return;
+    if (e.stdout) {
+      const stdout = JSON.parse(e.stdout);
+      if (stdout.error.code === 'E404') {
+        return;
+      }
+    }
     throw e;
   }
 }


### PR DESCRIPTION
This PR fixes this error: https://github.com/vitejs/vite-plugin-react/actions/runs/14352048933/job/40232861879#step:8:18
It seems npm changed the output and the detection no longer matches.
