### PR TITLE
fix: generate commit link for breaking changes

### DIFF
--- a/src/changelog.ts
+++ b/src/changelog.ts
@@ -40,16 +40,27 @@ export const generateChangelog: typeof def = async ({
 {{~#if isPatch~}} </small> {{~/if}}
 `.trim();
   preset.writer.mainTemplate = `
+{{> header}}
 {{#if noteGroups}}
 {{#each noteGroups}}
+
 ### ⚠ {{title}}
 
 {{#each notes}}
-* {{#if commit.scope}}**{{commit.scope}}:** {{/if}}{{text}}
-  {{#if commit.hash}}([{{commit.shortHash}}](https://github.com/{{@root.owner}}/{{@root.repository}}/commit/{{commit.hash}})){{/if}}
+* {{#if commit.scope}}**{{commit.scope}}:** {{/if}}{{text}}{{#if commit.hash}}([{{commit.shortHash}}](https://github.com/{{@root.owner}}/{{@root.repository}}/commit/{{commit.hash}})){{/if}}
 {{/each}}
 {{/each}}
-{{/if}}\n`.trim();
+{{/if}}
+{{#each commitGroups}}
+
+{{#if title}}
+### {{title}}
+
+{{/if}}
+{{#each commits}}
+{{> commit root=@root}}
+{{/each}}
+{{/each}}\n`.trim();
 
   const pkgDir = getPkgDir();
 

--- a/src/changelog.ts
+++ b/src/changelog.ts
@@ -60,7 +60,7 @@ export const generateChangelog: typeof def = async ({
 {{#each commits}}
 {{> commit root=@root}}
 {{/each}}
-{{/each}}\n`.trim();
+{{/each}}`.trim() + '\n';
 
   const pkgDir = getPkgDir();
 

--- a/src/changelog.ts
+++ b/src/changelog.ts
@@ -39,7 +39,17 @@ export const generateChangelog: typeof def = async ({
 {{~/if}}
 {{~#if isPatch~}} </small> {{~/if}}
 `.trim();
-  preset.writer.mainTemplate! += "\n";
+  preset.writer.mainTemplate = `
+{{#if noteGroups}}
+{{#each noteGroups}}
+### ⚠ {{title}}
+
+{{#each notes}}
+* {{#if commit.scope}}**{{commit.scope}}:** {{/if}}{{text}}
+  {{#if commit.hash}}([{{commit.shortHash}}](https://github.com/{{@root.owner}}/{{@root.repository}}/commit/{{commit.hash}})){{/if}}
+{{/each}}
+{{/each}}
+{{/if}}\n`.trim();
 
   const pkgDir = getPkgDir();
 

--- a/src/changelog.ts
+++ b/src/changelog.ts
@@ -39,7 +39,8 @@ export const generateChangelog: typeof def = async ({
 {{~/if}}
 {{~#if isPatch~}} </small> {{~/if}}
 `.trim();
-  preset.writer.mainTemplate = `
+  preset.writer.mainTemplate =
+    `
 {{> header}}
 {{#if noteGroups}}
 {{#each noteGroups}}
@@ -60,7 +61,7 @@ export const generateChangelog: typeof def = async ({
 {{#each commits}}
 {{> commit root=@root}}
 {{/each}}
-{{/each}}`.trim() + '\n';
+{{/each}}`.trim() + "\n";
 
   const pkgDir = getPkgDir();
 

--- a/src/changelog.ts
+++ b/src/changelog.ts
@@ -47,7 +47,7 @@ export const generateChangelog: typeof def = async ({
 ### ⚠ {{title}}
 
 {{#each notes}}
-* {{#if commit.scope}}**{{commit.scope}}:** {{/if}}{{text}}{{#if commit.hash}}([{{commit.shortHash}}](https://github.com/{{@root.owner}}/{{@root.repository}}/commit/{{commit.hash}})){{/if}}
+* {{#if commit.scope}}**{{commit.scope}}:** {{/if}}{{commit.subject}} {{#if commit.hash}}([{{commit.shortHash}}](https://github.com/{{@root.owner}}/{{@root.repository}}/commit/{{commit.hash}})){{/if}}
 {{/each}}
 {{/each}}
 {{/if}}


### PR DESCRIPTION
There is no corresponding commit link in the `breaking changes` group of the latest generated changelog, which makes it inconvenient to view.

<img width="897" height="455" alt="image" src="https://github.com/user-attachments/assets/7c0e2445-24c9-4070-80f4-0273789c5b8f" />
