### PR TITLE
refactor: replace execa with tinyexec

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,12 +26,12 @@
     "release": "tnode scripts/release.ts"
   },
   "dependencies": {
-    "execa": "^8.0.1",
     "mri": "^1.2.0",
     "picocolors": "^1.1.1",
     "prompts": "^2.4.2",
     "publint": "^0.3.2",
-    "semver": "^7.6.3"
+    "semver": "^7.6.3",
+    "tinyexec": "^0.3.2"
   },
   "devDependencies": {
     "@arnaud-barre/tnode": "^0.24.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,6 @@ importers:
 
   .:
     dependencies:
-      execa:
-        specifier: ^8.0.1
-        version: 8.0.1
       mri:
         specifier: ^1.2.0
         version: 1.2.0
@@ -26,6 +23,9 @@ importers:
       semver:
         specifier: ^7.6.3
         version: 7.6.3
+      tinyexec:
+        specifier: ^0.3.2
+        version: 0.3.2
     devDependencies:
       '@arnaud-barre/tnode':
         specifier: ^0.24.0
@@ -218,67 +218,21 @@ packages:
   '@types/semver@7.5.8':
     resolution: {integrity: sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==}
 
-  cross-spawn@7.0.3:
-    resolution: {integrity: sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==}
-    engines: {node: '>= 8'}
-
   esbuild@0.24.2:
     resolution: {integrity: sha512-+9egpBW8I3CD5XPe0n6BfT5fxLzxrlDzqydF3aviG+9ni1lDC/OvMHcxqEFV0+LANZG5R1bFMWfUrjVsdwxJvA==}
     engines: {node: '>=18'}
     hasBin: true
 
-  execa@8.0.1:
-    resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
-    engines: {node: '>=16.17'}
-
-  get-stream@8.0.1:
-    resolution: {integrity: sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==}
-    engines: {node: '>=16'}
-
-  human-signals@5.0.0:
-    resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
-    engines: {node: '>=16.17.0'}
-
-  is-stream@3.0.0:
-    resolution: {integrity: sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
-  isexe@2.0.0:
-    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
-
   kleur@3.0.3:
     resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
     engines: {node: '>=6'}
-
-  merge-stream@2.0.0:
-    resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
-
-  mimic-fn@4.0.0:
-    resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
-    engines: {node: '>=12'}
 
   mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
     engines: {node: '>=4'}
 
-  npm-run-path@5.1.0:
-    resolution: {integrity: sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
-  onetime@6.0.0:
-    resolution: {integrity: sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==}
-    engines: {node: '>=12'}
-
   package-manager-detector@0.2.8:
     resolution: {integrity: sha512-ts9KSdroZisdvKMWVAVCXiKqnqNfXz4+IbrBG8/BWx/TR5le+jfenvoBuIZ6UWM9nz47W7AbD9qYfAwfWMIwzA==}
-
-  path-key@3.1.1:
-    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
-    engines: {node: '>=8'}
-
-  path-key@4.0.0:
-    resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
-    engines: {node: '>=12'}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -306,24 +260,11 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  shebang-command@2.0.0:
-    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
-    engines: {node: '>=8'}
-
-  shebang-regex@3.0.0:
-    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
-    engines: {node: '>=8'}
-
-  signal-exit@4.1.0:
-    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
-    engines: {node: '>=14'}
-
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
-  strip-final-newline@3.0.0:
-    resolution: {integrity: sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==}
-    engines: {node: '>=12'}
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
 
   typescript@5.7.3:
     resolution: {integrity: sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==}
@@ -332,11 +273,6 @@ packages:
 
   undici-types@6.20.0:
     resolution: {integrity: sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==}
-
-  which@2.0.2:
-    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
-    engines: {node: '>= 8'}
-    hasBin: true
 
 snapshots:
 
@@ -432,12 +368,6 @@ snapshots:
 
   '@types/semver@7.5.8': {}
 
-  cross-spawn@7.0.3:
-    dependencies:
-      path-key: 3.1.1
-      shebang-command: 2.0.0
-      which: 2.0.2
-
   esbuild@0.24.2:
     optionalDependencies:
       '@esbuild/aix-ppc64': 0.24.2
@@ -466,47 +396,11 @@ snapshots:
       '@esbuild/win32-ia32': 0.24.2
       '@esbuild/win32-x64': 0.24.2
 
-  execa@8.0.1:
-    dependencies:
-      cross-spawn: 7.0.3
-      get-stream: 8.0.1
-      human-signals: 5.0.0
-      is-stream: 3.0.0
-      merge-stream: 2.0.0
-      npm-run-path: 5.1.0
-      onetime: 6.0.0
-      signal-exit: 4.1.0
-      strip-final-newline: 3.0.0
-
-  get-stream@8.0.1: {}
-
-  human-signals@5.0.0: {}
-
-  is-stream@3.0.0: {}
-
-  isexe@2.0.0: {}
-
   kleur@3.0.3: {}
-
-  merge-stream@2.0.0: {}
-
-  mimic-fn@4.0.0: {}
 
   mri@1.2.0: {}
 
-  npm-run-path@5.1.0:
-    dependencies:
-      path-key: 4.0.0
-
-  onetime@6.0.0:
-    dependencies:
-      mimic-fn: 4.0.0
-
   package-manager-detector@0.2.8: {}
-
-  path-key@3.1.1: {}
-
-  path-key@4.0.0: {}
 
   picocolors@1.1.1: {}
 
@@ -530,22 +424,10 @@ snapshots:
 
   semver@7.6.3: {}
 
-  shebang-command@2.0.0:
-    dependencies:
-      shebang-regex: 3.0.0
-
-  shebang-regex@3.0.0: {}
-
-  signal-exit@4.1.0: {}
-
   sisteransi@1.0.5: {}
 
-  strip-final-newline@3.0.0: {}
+  tinyexec@0.3.2: {}
 
   typescript@5.7.3: {}
 
   undici-types@6.20.0: {}
-
-  which@2.0.2:
-    dependencies:
-      isexe: 2.0.0

--- a/src/release.ts
+++ b/src/release.ts
@@ -101,7 +101,9 @@ export const release: typeof def = async ({
   updateVersion(pkgPath, targetVersion);
   await generateChangelog(selectedPkg, targetVersion);
 
-  const { stdout } = await run("git", ["diff"], { stdio: "pipe" });
+  const { stdout } = await run("git", ["diff"], {
+    nodeOptions: { stdio: "pipe" },
+  });
   if (stdout) {
     step("\nCommitting changes...");
     await runIfNotDry("git", ["add", "-A"]);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -44,12 +44,12 @@ export async function run(
   opts: Partial<TinyExecOptions> = {},
 ): Promise<TinyExecResult> {
   return exec(bin, args, {
+    throwOnError: true,
+    ...opts,
     nodeOptions: {
       stdio: "inherit",
       ...opts.nodeOptions,
     },
-    throwOnError: true,
-    ...opts,
   });
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -161,9 +161,7 @@ export async function publishPackage(
     publicArgs.push(`--no-git-checks`);
   }
   await runIfNotDry(packageManager, publicArgs, {
-    nodeOptions: {
-      cwd: pkgDir,
-    },
+    nodeOptions: { cwd: pkgDir },
   });
 }
 

--- a/tests/changelog.test.ts
+++ b/tests/changelog.test.ts
@@ -2,7 +2,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { it, expect, onTestFinished } from "vitest";
 import { createFixture, type FileTree } from "fs-fixture";
-import { execa } from "execa";
+import { exec } from "tinyexec";
 import { generateChangelog } from "../src/changelog.ts";
 
 async function createProjectFixture(source?: FileTree) {
@@ -16,11 +16,11 @@ async function createProjectFixture(source?: FileTree) {
   });
   onTestFinished(() => fixture.rm());
 
-  await execa("git", ["init"], { cwd: fixture.path });
-  await execa(
+  await exec("git", ["init"], { nodeOptions: { cwd: fixture.path } });
+  await exec(
     "git",
     ["remote", "add", "origin", "https://github.com/vitejs/test.git"],
-    { cwd: fixture.path },
+    { nodeOptions: { cwd: fixture.path } },
   );
 
   return fixture;
@@ -32,8 +32,8 @@ async function gitCommit(cwd: string, message: string) {
     path.join(cwd, "dummy.txt"),
     Math.random().toString(36).substring(2, 15),
   );
-  await execa("git", ["add", "."], { cwd });
-  await execa("git", ["commit", "-m", message], { cwd });
+  await exec("git", ["add", "."], { nodeOptions: { cwd } });
+  await exec("git", ["commit", "-m", message], { nodeOptions: { cwd } });
 }
 
 async function updatePackageJsonVersion(cwd: string, version: string) {
@@ -57,7 +57,7 @@ async function generateChangelogForRelease(cwd: string) {
     await fs.readFile(path.join(cwd, "./package.json"), "utf8"),
   ).version;
   const tag = `v${version}`;
-  await execa("git", ["tag", "-a", "-m", tag, tag], { cwd });
+  await exec("git", ["tag", "-a", "-m", tag, tag], { nodeOptions: { cwd } });
 }
 
 async function readChangelog(cwd: string) {


### PR DESCRIPTION
Just swapping to tinyexec which is lighter-weight.

I don't quite remember why I didn't send the PR before.