### PR TITLE
build: simplify exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,5 +41,5 @@
     "typescript": "^5.8.3",
     "vitest": "^3.2.4"
   },
-  "packageManager": "pnpm@10.15.0"
+  "packageManager": "pnpm@10.13.1"
 }

--- a/package.json
+++ b/package.json
@@ -3,17 +3,11 @@
   "version": "1.6.0",
   "description": "@vitejs release scripts",
   "license": "MIT",
-  "main": "dist/index.js",
   "type": "module",
   "files": [
     "dist"
   ],
-  "exports": {
-    ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
-    }
-  },
+  "exports": "./dist/index.js",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/vitejs/release-scripts.git"
@@ -47,5 +41,5 @@
     "typescript": "^5.8.3",
     "vitest": "^3.2.4"
   },
-  "packageManager": "pnpm@10.13.1"
+  "packageManager": "pnpm@10.15.0"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+onlyBuiltDependencies:
+  - esbuild

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,0 @@
-onlyBuiltDependencies:
-  - esbuild


### PR DESCRIPTION
Simplify the exports similar to [plugin-legacy](https://github.com/vitejs/vite/blob/main/packages/plugin-legacy/package.json). I think it shouldn't be a breaking change as our deps, e.g. publint, already requires node 18 and above, which should always skip the `"main"` fields anyways.