### PR TITLE
feat: make org in release command output configurable

### DIFF
--- a/src/release.ts
+++ b/src/release.ts
@@ -16,7 +16,7 @@ import { publint } from "publint";
 import { formatMessage } from "publint/utils";
 
 export const release: typeof def = async ({
-  org = 'vitejs',
+  org = "vitejs",
   repo,
   packages,
   logChangelog,

--- a/src/release.ts
+++ b/src/release.ts
@@ -16,6 +16,7 @@ import { publint } from "publint";
 import { formatMessage } from "publint/utils";
 
 export const release: typeof def = async ({
+  org = 'vitejs',
   repo,
   packages,
   logChangelog,
@@ -125,7 +126,7 @@ export const release: typeof def = async ({
       colors.green(
         `
 Pushed, publishing should starts shortly on CI.
-https://github.com/vitejs/${repo}/actions/workflows/publish.yml`,
+https://github.com/${org}/${repo}/actions/workflows/publish.yml`,
       ),
     );
   }

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -21,6 +21,8 @@ export declare function publish(options: {
 }): Promise<void>;
 
 export declare function release(options: {
+  /** @default 'vitejs' */
+  org?: string;
   repo: string;
   packages: string[];
   logChangelog: (pkg: string) => void | Promise<void>;


### PR DESCRIPTION
so that I can remove the patch here: https://github.com/rolldown/plugins/blob/e0e474c00f1fcc237b81c3c64ad71de488227db7/patches/%40vitejs__release-scripts%401.6.0.patch