### PR TITLE
fix: add line break between versions in changelog

### DIFF
--- a/src/changelog.ts
+++ b/src/changelog.ts
@@ -79,6 +79,6 @@ export const generateChangelog: typeof def = async ({ getPkgDir, tagPrefix }) =>
   for await (const chunk of generator.write()) {
     writeStream.write(chunk);
   }
-  writeStream.write('\n');
+  writeStream.write("\n");
   writeStream.write(originalChangelog);
 };

--- a/src/changelog.ts
+++ b/src/changelog.ts
@@ -79,5 +79,6 @@ export const generateChangelog: typeof def = async ({ getPkgDir, tagPrefix }) =>
   for await (const chunk of generator.write()) {
     writeStream.write(chunk);
   }
+  writeStream.write('\n');
   writeStream.write(originalChangelog);
 };

--- a/tests/__snapshots__/changelog.test.ts.snap
+++ b/tests/__snapshots__/changelog.test.ts.snap
@@ -13,10 +13,12 @@ exports[`generates a changelog with breaking changes 1`] = `
 ### Bug Fixes
 
 * fix a bug ([#1](https://github.com/vitejs/test/issues/1)) ([xxxxxxx](https://github.com/vitejs/test/commit/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx))
+
 ## 1.0.0 (yyyy-mm-dd)
 ### Miscellaneous Chores
 
 * initial commit ([xxxxxxx](https://github.com/vitejs/test/commit/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx))
+
 "
 `;
 
@@ -25,10 +27,12 @@ exports[`generates a changelog with commits 1`] = `
 ### Bug Fixes
 
 * fix a bug ([#1](https://github.com/vitejs/test/issues/1)) ([xxxxxxx](https://github.com/vitejs/test/commit/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx))
+
 ## 1.0.0 (yyyy-mm-dd)
 ### Miscellaneous Chores
 
 * initial commit ([xxxxxxx](https://github.com/vitejs/test/commit/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx))
+
 "
 `;
 
@@ -37,14 +41,17 @@ exports[`generates a changelog with commits 2`] = `
 ### Features
 
 * add new feature ([xxxxxxx](https://github.com/vitejs/test/commit/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx))
+
 ## <small>[1.0.1](https://github.com/vitejs/test/compare/v1.0.0...v1.0.1) (yyyy-mm-dd)</small>
 ### Bug Fixes
 
 * fix a bug ([#1](https://github.com/vitejs/test/issues/1)) ([xxxxxxx](https://github.com/vitejs/test/commit/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx))
+
 ## 1.0.0 (yyyy-mm-dd)
 ### Miscellaneous Chores
 
 * initial commit ([xxxxxxx](https://github.com/vitejs/test/commit/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx))
+
 "
 `;
 
@@ -53,5 +60,6 @@ exports[`generates a new changelog for empty project 1`] = `
 ### Miscellaneous Chores
 
 * initial commit ([xxxxxxx](https://github.com/vitejs/test/commit/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx))
+
 "
 `;


### PR DESCRIPTION
Not sure why but the line breaks between versions was missing.