### PR TITLE
fix: only include commits from relevant directory

### DIFF
--- a/src/changelog.ts
+++ b/src/changelog.ts
@@ -66,7 +66,8 @@ export const generateChangelog: typeof def = async ({ getPkgDir, tagPrefix }) =>
   const generator = new ConventionalChangelog(pkgDir)
     .readPackage()
     .config(preset)
-    .options({ releaseCount: 1 });
+    .options({ releaseCount: 1 })
+    .commits({ path: "." });
   if (tagPrefix) {
     generator.tags({ prefix: tagPrefix });
   }


### PR DESCRIPTION
It was including irrelevant commits: https://github.com/vitejs/vite/commit/a4cd63c7810b94a049e1efa9a359a218cb9a5d20

refs #76