### PR TITLE
ci: disable cache for publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,13 +19,15 @@ jobs:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 24
+          # disable cache, to avoid cache poisoning (https://docs.zizmor.sh/audits/#cache-poisoning)
+          package-manager-cache: false
       - run: corepack enable
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 24
           registry-url: "https://registry.npmjs.org"
-          cache: "pnpm"
-          cache-dependency-path: "**/pnpm-lock.yaml"
+          # disable cache, to avoid cache poisoning (https://docs.zizmor.sh/audits/#cache-poisoning)
+          package-manager-cache: false
       - run: pnpm install --frozen-lockfile --prefer-offline
       - run: pnpm build
       - run: node scripts/publish.ts "$GITHUB_REF_NAME"


### PR DESCRIPTION
https://docs.zizmor.sh/audits/#cache-poisoning

setup-node v6 does not enable cache for pnpm unless `cache` is set, but added `package-manager-cache: false` explicitly as well so that it's clear.

