### PR TITLE
feat: allow `target-branch` option in release-pr-action

### DIFF
--- a/action/release-pr/action.yml
+++ b/action/release-pr/action.yml
@@ -20,6 +20,10 @@ inputs:
   tag:
     description: Release tag
     required: true
+  target-branch:
+    description: Branch the release pull request targets
+    required: false
+    default: main
   version:
     description: Release version
     required: true
@@ -36,6 +40,7 @@ runs:
         PACKAGE_PATH: ${{ inputs.package-path }}
         PR_BODY: ${{ inputs.pr-body }}
         TAG: ${{ inputs.tag }}
+        TARGET_BRANCH: ${{ inputs.target-branch }}
         VERSION: ${{ inputs.version }}
       run: |
         BRANCH="release-$PACKAGE_NAME-$VERSION-$GITHUB_RUN_ID"
@@ -49,7 +54,7 @@ runs:
         git push -u "https://x-access-token:$GH_TOKEN@github.com/$GITHUB_REPOSITORY.git" HEAD
         gh pr create \
           --assignee "$GITHUB_ACTOR" \
-          --base main \
+          --base "$TARGET_BRANCH" \
           --head "$BRANCH" \
           --title "release: $TAG" \
           --body "$PR_BODY"


### PR DESCRIPTION
Needed for https://github.com/vitejs/vite/pull/23394